### PR TITLE
remove implicit saveGraphicState from the setShadow method

### DIFF
--- a/Lib/pagebot/contexts/drawbotcontext.py
+++ b/Lib/pagebot/contexts/drawbotcontext.py
@@ -207,9 +207,7 @@ class DrawBotContext(BaseContext):
     #   G R A D I E N T  &  S H A D O W
 
     def setShadow(self, eShadow):
-        u"""Set the DrawBot graphics state for shadow if all parameters are set.
-        Pair the call of this method with self.resetShadow()"""
-        self.saveGraphicState()
+        u"""Set the DrawBot graphics state for shadow if all parameters are set."""
         if eShadow is not None and eShadow.offset is not None:
             if eShadow.cmykColor is not None:
                 self.b.shadow(eShadow.offset,
@@ -219,9 +217,6 @@ class DrawBotContext(BaseContext):
                 self.b.shadow(eShadow.offset,
                               blur=eShadow.blur,
                               color=eShadow.color)
-
-    def resetShadow(self):
-        self.restoreGraphicState()
 
     def setGradient(self, gradient, origin, w, h):
         u"""Define the gradient call to match the size of element e., Gradient position

--- a/Lib/pagebot/contexts/flatcontext.py
+++ b/Lib/pagebot/contexts/flatcontext.py
@@ -388,11 +388,7 @@ class FlatContext(BaseContext):
     #   S H A D O W  &  G R A D I E N T
 
     def setShadow(self, eShadow):
-        u"""Set the DrawBot graphics state for shadow if all parameters are set. Pair the call of this
-        method with self._resetShadow()"""
-        pass # Not implemented?
-
-    def resetShadow(self):
+        u"""Set the DrawBot graphics state for shadow if all parameters are set."""
         pass # Not implemented?
 
     def setGradient(self, gradient, origin, w, h):

--- a/Lib/pagebot/elements/views/pageview.py
+++ b/Lib/pagebot/elements/views/pageview.py
@@ -414,6 +414,7 @@ class PageView(BaseView):
             p = e._applyOrigin(self, p)
             p = e._applyScale(p)
             px, py, _ = e._applyAlignment(p) # Ignore z-axis for now.
+            context.saveGraphicState()
             context.setShadow(self.shadow)
 
             sMissingElementFill = self.css('viewMissingElementFill', NO_COLOR)
@@ -432,7 +433,7 @@ class PageView(BaseView):
             context.lineTo((px, py + self.h))
             context.drawPath()
 
-            context.resetShadow()
+            context.restoreGraphicState()
             e._restoreScale()
 
     #    G R I D


### PR DESCRIPTION
because it is error prone to do so. Actually there were already mismatching save/restore calls in the code due to that implicit save.