### PR TITLE
make doctest errors break Travis

### DIFF
--- a/Examples/Howto/UseText/Hyphenation.py
+++ b/Examples/Howto/UseText/Hyphenation.py
@@ -61,4 +61,5 @@ def hyphenDemo(s, language='en'):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Examples/Howto/UseUnits.py
+++ b/Examples/Howto/UseUnits.py
@@ -46,4 +46,5 @@ def useUnits():
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/__init__.py
+++ b/Lib/pagebot/__init__.py
@@ -328,9 +328,7 @@ def findMarkers(fs, reCompiled=None):
     return reCompiled.findall(u'%s' % fs)
 
 
-
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/conditions/align.py
+++ b/Lib/pagebot/conditions/align.py
@@ -840,8 +840,7 @@ class Origin2BottomSide(Condition):
 			self.addScore(e.origin2BottomSide(), e, score)
 
 
-
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/conditions/flow.py
+++ b/Lib/pagebot/conditions/flow.py
@@ -107,5 +107,6 @@ class FloatXHeight2Top(Condition):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])
 

--- a/Lib/pagebot/contexts/basecontext.py
+++ b/Lib/pagebot/contexts/basecontext.py
@@ -95,6 +95,5 @@ class BaseContext(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-   
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/builders/htmlbuilder.py
+++ b/Lib/pagebot/contexts/builders/htmlbuilder.py
@@ -1666,5 +1666,5 @@ table {
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/drawbotcontext.py
+++ b/Lib/pagebot/contexts/drawbotcontext.py
@@ -561,6 +561,5 @@ class DrawBotContext(BaseContext):
         
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-   
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/flatcontext.py
+++ b/Lib/pagebot/contexts/flatcontext.py
@@ -513,6 +513,5 @@ class FlatContext(BaseContext):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-  
+    import sys
+    sys.exit(doctest.testmod()[0]) 

--- a/Lib/pagebot/contexts/htmlcontext.py
+++ b/Lib/pagebot/contexts/htmlcontext.py
@@ -74,6 +74,5 @@ class HtmlContext(BaseContext):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-  
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/platform.py
+++ b/Lib/pagebot/contexts/platform.py
@@ -70,6 +70,5 @@ def getFontPaths():
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-  
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/strings/babelstring.py
+++ b/Lib/pagebot/contexts/strings/babelstring.py
@@ -65,6 +65,5 @@ class BabelString(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-  
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/strings/drawbotstring.py
+++ b/Lib/pagebot/contexts/strings/drawbotstring.py
@@ -624,5 +624,5 @@ def findPattern(textLines, pattern):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contexts/strings/flatstring.py
+++ b/Lib/pagebot/contexts/strings/flatstring.py
@@ -125,7 +125,5 @@ class FlatString(BabelString):
         
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-   
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/contributions/filibuster/blurbwriter.py
+++ b/Lib/pagebot/contributions/filibuster/blurbwriter.py
@@ -420,6 +420,7 @@ class BlurbWriter(object):
                     self.softdefine(tg, vardef)
         return 0, text
 
+<<<<<<< 94337a25d30ecf1f98027c124bd24c8c3de83f36
 
 def test():
     u"""
@@ -561,4 +562,5 @@ def test():
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/document.py
+++ b/Lib/pagebot/document.py
@@ -659,5 +659,5 @@ class Document(object):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/element.py
+++ b/Lib/pagebot/elements/element.py
@@ -4191,4 +4191,5 @@ class Element(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/paths/glyphpath.py
+++ b/Lib/pagebot/elements/paths/glyphpath.py
@@ -109,6 +109,5 @@ class GlyphPath(Path):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbgalley.py
+++ b/Lib/pagebot/elements/pbgalley.py
@@ -170,5 +170,5 @@ class Galley(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbimage.py
+++ b/Lib/pagebot/elements/pbimage.py
@@ -318,6 +318,5 @@ class PixelMap(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbline.py
+++ b/Lib/pagebot/elements/pbline.py
@@ -102,4 +102,5 @@ class Line(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pboval.py
+++ b/Lib/pagebot/elements/pboval.py
@@ -83,5 +83,5 @@ class Oval(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbplacer.py
+++ b/Lib/pagebot/elements/pbplacer.py
@@ -62,5 +62,5 @@ class Placer(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbrect.py
+++ b/Lib/pagebot/elements/pbrect.py
@@ -56,5 +56,5 @@ class Rect(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbruler.py
+++ b/Lib/pagebot/elements/pbruler.py
@@ -144,4 +144,5 @@ class Ruler(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/pbtextbox.py
+++ b/Lib/pagebot/elements/pbtextbox.py
@@ -456,6 +456,5 @@ class TextBox(Element):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/elements/views/pageview.py
+++ b/Lib/pagebot/elements/views/pageview.py
@@ -727,6 +727,6 @@ class PageView(BaseView):
         pass
 
 if __name__ == "__main__":
+    import sys
     import doctest
-    doctest.testmod()
-
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/installfont.py
+++ b/Lib/pagebot/fonttoolbox/installfont.py
@@ -97,7 +97,8 @@ def _runDocTests():
 from pagebot.contexts import defaultContext as c
 if __name__ == "__main__":
     if True:
-        _runDocTests()
+        import sys
+        sys.exit(_runDocTests()[0])
     else:
         # Test to be run in DrawBot
         from tnTestFonts import getFontPath

--- a/Lib/pagebot/fonttoolbox/mutator.py
+++ b/Lib/pagebot/fonttoolbox/mutator.py
@@ -241,4 +241,5 @@ def getVariableFont(fontOrPath, location, install=True, styleName=None, normaliz
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/objects/family.py
+++ b/Lib/pagebot/fonttoolbox/objects/family.py
@@ -350,7 +350,5 @@ class Family(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
-  
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/objects/font.py
+++ b/Lib/pagebot/fonttoolbox/objects/font.py
@@ -295,6 +295,5 @@ class Font(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/objects/glyph.py
+++ b/Lib/pagebot/fonttoolbox/objects/glyph.py
@@ -537,5 +537,5 @@ class Glyph(object):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/objects/varfamily.py
+++ b/Lib/pagebot/fonttoolbox/objects/varfamily.py
@@ -255,6 +255,5 @@ class VarFamily(Family):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/fonttoolbox/otlTools.py
+++ b/Lib/pagebot/fonttoolbox/otlTools.py
@@ -1537,7 +1537,8 @@ def _runDocTests():
 
 if __name__ == "__main__":
     if True:
-        _runDocTests()
+        import sys
+        sys.exit(_runDocTests()[0])
     if False:
         gposFormats = ['SinglePosFormat1', 'SinglePosFormat2', 'PairPosFormat1', 'PairPosFormat2', 'CursivePosFormat1', 'MarkBasePosFormat1', 'MarkLigPosFormat1', 'MarkMarkPosFormat1', 'ContextPosFormat1', 'ContextPosFormat2', 'ContextPosFormat3', 'ChainContextPosFormat1', 'ChainContextPosFormat2', 'ChainContextPosFormat3', 'ExtensionPosFormat1']
         gsubFormats = ['SingleSubstFormat1', 'SingleSubstFormat2', 'MultipleSubstFormat1', 'AlternateSubstFormat1', 'LigatureSubstFormat1', 'ContextSubstFormat1', 'ContextSubstFormat2', 'ContextSubstFormat3', 'ChainContextSubstFormat1', 'ChainContextSubstFormat2', 'ChainContextSubstFormat3', 'ExtensionSubstFormat1', 'ReverseChainSingleSubstFormat1']

--- a/Lib/pagebot/fonttoolbox/ttftools.py
+++ b/Lib/pagebot/fonttoolbox/ttftools.py
@@ -944,7 +944,8 @@ def _runDocTests():
 
 if __name__ == "__main__":
     if True:
-        _runDocTests()
+        import sys
+        sys.exit(_runDocTests()[0])
     else:
         import os
         from fontTools.ttLib import TTFont

--- a/Lib/pagebot/fonttoolbox/unicodes/unicoderanges.py
+++ b/Lib/pagebot/fonttoolbox/unicodes/unicoderanges.py
@@ -458,7 +458,8 @@ def _runDocTests():
 
 
 if __name__ == "__main__":
-    _runDocTests()
+    import sys
+    sys.exit(_runDocTests()[0])
     if 0:
         from random import randint
         for i in range(100):

--- a/Lib/pagebot/publications/typespecimen.py
+++ b/Lib/pagebot/publications/typespecimen.py
@@ -146,5 +146,5 @@ class TypeSpecimen(Publication):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
-         
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/publications/website.py
+++ b/Lib/pagebot/publications/website.py
@@ -327,5 +327,5 @@ class Website(Publication):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()     
-  
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/toolbox/dating.py
+++ b/Lib/pagebot/toolbox/dating.py
@@ -967,6 +967,5 @@ class DateTime:
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
-
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/toolbox/markers.py
+++ b/Lib/pagebot/toolbox/markers.py
@@ -107,5 +107,5 @@ def drawCropMarks(context, origin, w, h, bleed, cmSize, cmStrokeWidth, folds=Non
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
-
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/toolbox/mathematics.py
+++ b/Lib/pagebot/toolbox/mathematics.py
@@ -208,4 +208,5 @@ def normalize(p, length=1):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/toolbox/transformer.py
+++ b/Lib/pagebot/toolbox/transformer.py
@@ -1296,4 +1296,5 @@ def value2Bool(v):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])

--- a/Lib/pagebot/toolbox/units.py
+++ b/Lib/pagebot/toolbox/units.py
@@ -181,4 +181,5 @@ class perc(RelativeUnit):
 
 if __name__ == '__main__':
     import doctest
-    doctest.testmod()
+    import sys
+    sys.exit(doctest.testmod()[0])


### PR DESCRIPTION
These errors were being ignored on travis builds.

https://travis-ci.org/TypeNetwork/PageBot/builds/345878628?utm_source=github_status&utm_medium=notification

![screenshot at 2018-02-26 17 10 36](https://user-images.githubusercontent.com/213676/36692833-fdfcf516-1b17-11e8-8346-a9873ca6b1e6.png)
