### PR TITLE
Fix flatcontext Examples/001_Basics/UseDocuments.py

### DIFF
--- a/Examples/500_Guided_Tour/GuidedTour.md
+++ b/Examples/500_Guided_Tour/GuidedTour.md
@@ -16,6 +16,8 @@ This file (and all other MarkDown files (extension *.md*) can best be viewed and
 
 Free license: [https://macdown.uranusjr.com](https://macdown.uranusjr.com)
 
+On GNU/Linux and Windows e.g. [Remarkable](https://remarkableapp.github.io/) is an adequate MarkDown editor.
+
 ### Sublime 
 
 The Pagebot library code can be viewed and modified by Sublime (and other Python-based editors). And advantage of Sublime is that code can be executed from inside the editor, so it can run the doctests with direct feedback about validity of the code.

--- a/Lib/pagebot/contexts/flatcontext.py
+++ b/Lib/pagebot/contexts/flatcontext.py
@@ -486,12 +486,15 @@ class FlatContext(BaseContext):
         # TODO: Make better match for all file types, transparance and spot color
         import flat
 
+        def to255(vals):
+            return [round(val * 255) for val in vals]
+
         if self.fileType in (FILETYPE_JPG, FILETYPE_PNG):
-            return flat.rgb(*c.rgb)
+            return flat.rgb(*to255(c.rgb))
             #return c.rgb
         if self.fileType in (FILETYPE_PDF):
-            return flat.rgb(*c.rgb)
-        return flat.rgb(*c.rgb)
+            return flat.rgb(*to255(c.rgb))
+        return flat.rgb(*to255(c.rgb))
         #return c.rgb
 
     def _getShape(self):

--- a/Lib/pagebot/toolbox/units.py
+++ b/Lib/pagebot/toolbox/units.py
@@ -774,7 +774,7 @@ class Unit:
         >>> float(pt(20.2))
         20.2
         """
-        return self.pt
+        return float(self.pt)
 
     def __round__(self):
         """Answer the rounded self as value.


### PR DESCRIPTION
This is what I figured on our PageBot workshop on Monday in Brussels.

Needs also https://github.com/TypeNetwork/flat/pull/1 to make `Examples/001_Basics/UseDocuments.py` work with the flat context.